### PR TITLE
REST Endpoint Phase 2

### DIFF
--- a/Sulfur/Constants/ServiceConstants.cs
+++ b/Sulfur/Constants/ServiceConstants.cs
@@ -12,5 +12,16 @@ namespace Sulfur.Constants
         //The auth password for the header token
         public static string AuthTokenPassword = "TEST";
 
+        //enums to be used by the UrlFileDownload service
+        public enum UrlFileDlEnums
+        {
+            INVALIDWEBFORMAT, NOFILEATURL, FILEINCORRECTFORMAT, SUCCESS
+        }
+
+        //constants to be used by the UrlActionService when determining a text message
+        public static string InvalidWebFormat = "Invalid Web format";
+        public static string NoFileAtUrl = "No file at url";
+        public static string FileIncorrectFormat = "File at url address is not a torrent";
+        public static string Success = "Success";
     }
 }

--- a/Sulfur/Constants/ServiceConstants.cs
+++ b/Sulfur/Constants/ServiceConstants.cs
@@ -15,13 +15,12 @@ namespace Sulfur.Constants
         //enums to be used by the UrlFileDownload service
         public enum UrlFileDlEnums
         {
-            INVALIDWEBFORMAT, NOFILEATURL, FILEINCORRECTFORMAT, SUCCESS
+            WEBURLISNOTVALID, FILEINCORRECTFORMAT, SUCCESS
         }
 
         //constants to be used by the UrlActionService when determining a text message
-        public static string InvalidWebFormat = "Invalid Web format";
-        public static string NoFileAtUrl = "No file at url";
-        public static string FileIncorrectFormat = "File at url address is not a torrent";
+        public static string InvalidWebUrl = "Web url is not valid";
+        public static string FileIncorrectFormat = "File at url address is not a torrent file";
         public static string Success = "Success";
     }
 }

--- a/Sulfur/Constants/ServiceConstants.cs
+++ b/Sulfur/Constants/ServiceConstants.cs
@@ -22,5 +22,8 @@ namespace Sulfur.Constants
         public static string InvalidWebUrl = "Web url is not valid";
         public static string FileIncorrectFormat = "File at url address is not a torrent file";
         public static string Success = "Success";
+
+        //used by the UrlFileDownload service when guessing a mime type
+        public static string TorrentMimeType = "application/x-bittorrent";
     }
 }

--- a/Sulfur/Controllers/TorrentFileController.cs
+++ b/Sulfur/Controllers/TorrentFileController.cs
@@ -37,6 +37,12 @@ namespace Sulfur
                 return BadRequest(ModelState);
             }
 
+            //process the url using the urlfiledownload service
+
+            //pass success or fail to urlactionservice and get back guid payload
+
+            //return guid payload
+
             //ActionResult is the base class for various results for example JSONResult or Result
             //You can return a various amount of things.
             //Return a guid value from the post request

--- a/Sulfur/Controllers/TorrentFileController.cs
+++ b/Sulfur/Controllers/TorrentFileController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Sulfur.Constants;
 using Sulfur.Models;
+using Sulfur.Services.UrlFileDownloadActions;
 using Sulfur.Services.UrlHeaderActions;
 
 namespace Sulfur
@@ -15,10 +16,12 @@ namespace Sulfur
     public class TorrentFileController : ControllerBase
     {
         private readonly IUrlActionService _urlActionService;
+        private readonly IUrlFileDownloadService _urlFileDownloadService;
 
-        public TorrentFileController(IUrlActionService urlActionService)
+        public TorrentFileController(IUrlActionService urlActionService, IUrlFileDownloadService urlFileDownloadService)
         {
             _urlActionService = urlActionService;
+            _urlFileDownloadService = urlFileDownloadService;
         }
 
         // POST api/TorrentFile
@@ -38,15 +41,12 @@ namespace Sulfur
             }
 
             //process the url using the urlfiledownload service
+            var tupleResponse = _urlFileDownloadService.ProcessUrl(url.Url);
 
             //pass success or fail to urlactionservice and get back guid payload
+            GuidResult result = _urlActionService.GenerateGuidPayload(tupleResponse.Item1, tupleResponse.Item2);
 
-            //return guid payload
-
-            //ActionResult is the base class for various results for example JSONResult or Result
-            //You can return a various amount of things.
-            //Return a guid value from the post request
-            return _urlActionService.GenerateGuidPayload();
+            return result;
         }
     }
 }

--- a/Sulfur/Controllers/TorrentFileController.cs
+++ b/Sulfur/Controllers/TorrentFileController.cs
@@ -37,13 +37,6 @@ namespace Sulfur
                 return BadRequest(ModelState);
             }
 
-            //Check also if the authtoken is valid also
-            if (!_urlActionService.SuccessfulMatchOnHeaderToken(headerAuthToken))
-            {
-                //Returns a 400 bad request
-                return BadRequest();
-            }
-
             //ActionResult is the base class for various results for example JSONResult or Result
             //You can return a various amount of things.
             //Return a guid value from the post request

--- a/Sulfur/Models/GuidResult.cs
+++ b/Sulfur/Models/GuidResult.cs
@@ -9,5 +9,7 @@ namespace Sulfur.Models
     public class GuidResult
     {
         public String Id { get; set; }
+        public String success { get; set; }
+        public String error { get; set; }
     }
 }

--- a/Sulfur/Services/UrlFileDownloadActions/IUrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/IUrlFileDownloadService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sulfur.Services.UrlFileDownloadActions
+{
+    public interface IUrlFileDownloadService
+    {
+    }
+}

--- a/Sulfur/Services/UrlFileDownloadActions/IUrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/IUrlFileDownloadService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sulfur.Constants;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -7,5 +8,6 @@ namespace Sulfur.Services.UrlFileDownloadActions
 {
     public interface IUrlFileDownloadService
     {
+        Tuple<bool, ServiceConstants.UrlFileDlEnums> ProcessUrl(String url);
     }
 }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -6,8 +6,11 @@ using System.Threading.Tasks;
 
 namespace Sulfur.Services.UrlFileDownloadActions
 {
-    public interface UrlFileDownloadService
+    public class UrlFileDownloadService : IUrlFileDownloadService
     {
-        Tuple<bool, ServiceConstants.UrlFileDlEnums> ProcessUrl(String url);
+        public Tuple<bool, ServiceConstants.UrlFileDlEnums> ProcessUrl(string url)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Sulfur.Services.UrlFileDownloadActions
+{
+    public interface UrlFileDownloadService
+    {
+    }
+}

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -1,4 +1,5 @@
-﻿using Sulfur.Constants;
+﻿using MimeDetective;
+using Sulfur.Constants;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +10,11 @@ namespace Sulfur.Services.UrlFileDownloadActions
 {
     public class UrlFileDownloadService : IUrlFileDownloadService
     {
-        //Attempts to 
+        //Attempts to download the file at the url
+        //Returns a bool and enum signifying if successfull
+        //false, WEBURLISNOTVALID - The url is not valid, could be a 500 or 404 and it was unable to download
+        //false, FILEINCORRECTFORMAT - The url is valid but the file at the url is not a torrent file
+        //true, SUCCESS - Url is valid, file is a torrent file and was able to download.
         public Tuple<bool, ServiceConstants.UrlFileDlEnums> ProcessUrl(string url)
         {
             if (ValidUrl(url))
@@ -51,9 +56,22 @@ namespace Sulfur.Services.UrlFileDownloadActions
             return true;
         }
 
-        private bool IsTorrentFile(String url)
+        private bool IsTorrentFile(String url, byte[] torrentFileAsBytes)
         {
+            FileType fileType = torrentFileAsBytes.GetFileType();
 
+            //if(fileType.Mime)
+        }
+
+        //Attempts to download the file into a byte array
+        private byte[] DownloadFileFromUrl(String url)
+        {
+            byte[] torrentFileAsByteArray;
+            using (var webClient = new WebClient())
+            {
+                torrentFileAsByteArray = webClient.DownloadData("uri src");
+                return torrentFileAsByteArray;
+            }
         }
     }
 }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -1,4 +1,5 @@
-﻿using MimeDetective;
+﻿using HeyRed.Mime;
+using MimeDetective;
 using Sulfur.Constants;
 using System;
 using System.Collections.Generic;
@@ -58,7 +59,8 @@ namespace Sulfur.Services.UrlFileDownloadActions
 
         private bool IsTorrentFile(String url, byte[] torrentFileAsBytes)
         {
-            FileType fileType = torrentFileAsBytes.GetFileType();
+            MimeGuesser.GuessExtension(torrentFileAsBytes); //=> image/jpeg
+
 
             //if(fileType.Mime)
         }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -1,5 +1,4 @@
 ﻿using HeyRed.Mime;
-using MimeDetective;
 using Sulfur.Constants;
 using System;
 using System.Collections.Generic;

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -20,13 +20,16 @@ namespace Sulfur.Services.UrlFileDownloadActions
         {
             if (ValidUrl(url))
             {
+                //Retrieve files as bytes, to be used by mime guesser
+                byte[] downloadFile = DownloadFileFromUrl(url);
 
-            }
-            else
-            {
-                return Tuple.Create<bool, ServiceConstants.UrlFileDlEnums>(false, ServiceConstants.UrlFileDlEnums.WEBURLISNOTVALID);
+                if (IsTorrentFile(downloadFile))
+                    return Tuple.Create<bool, ServiceConstants.UrlFileDlEnums>(true, ServiceConstants.UrlFileDlEnums.SUCCESS);
+                else
+                    return Tuple.Create<bool, ServiceConstants.UrlFileDlEnums>(false, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
             }
 
+            return Tuple.Create<bool, ServiceConstants.UrlFileDlEnums>(false, ServiceConstants.UrlFileDlEnums.WEBURLISNOTVALID);
         }
 
         //Returns whether the url is valid
@@ -58,12 +61,12 @@ namespace Sulfur.Services.UrlFileDownloadActions
         }
 
         //Checks if the file is a torrent file
-        private bool IsTorrentFile(String url, byte[] torrentFileAsBytes)
+        private bool IsTorrentFile(byte[] torrentFileAsBytes)
         {
             //Attempts to guess and return the file type
             string mimeType = MimeGuesser.GuessMimeType(torrentFileAsBytes); //=> image/jpeg
 
-            return mimeType.Equals(ServiceConstants.TorrentFileType);
+            return mimeType.Equals(ServiceConstants.TorrentMimeType);
         }
 
         //Attempts to download the file into a byte array

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sulfur.Constants;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -7,5 +8,6 @@ namespace Sulfur.Services.UrlFileDownloadActions
 {
     public interface UrlFileDownloadService
     {
+        Tuple<bool, ServiceConstants.UrlFileDlEnums> ProcessUrl(String url);
     }
 }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -74,7 +74,7 @@ namespace Sulfur.Services.UrlFileDownloadActions
             byte[] torrentFileAsByteArray;
             using (var webClient = new WebClient())
             {
-                torrentFileAsByteArray = webClient.DownloadData("uri src");
+                torrentFileAsByteArray = webClient.DownloadData(url);
                 return torrentFileAsByteArray;
             }
         }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -2,15 +2,58 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Sulfur.Services.UrlFileDownloadActions
 {
     public class UrlFileDownloadService : IUrlFileDownloadService
     {
+        //Attempts to 
         public Tuple<bool, ServiceConstants.UrlFileDlEnums> ProcessUrl(string url)
         {
-            throw new NotImplementedException();
+            if (ValidUrl(url))
+            {
+
+            }
+            else
+            {
+                return Tuple.Create<bool, ServiceConstants.UrlFileDlEnums>(false, ServiceConstants.UrlFileDlEnums.WEBURLISNOTVALID);
+            }
+
+        }
+
+        //Returns whether the url is valid
+        private bool ValidUrl(string url)
+        {
+            HttpWebResponse response = null;
+            var request = (HttpWebRequest)WebRequest.Create(url);
+            request.Method = "HEAD";
+
+            try
+            {
+                response = (HttpWebResponse)request.GetResponse();
+            }
+            catch (WebException ex)
+            {
+                /* A WebException will be thrown if the status of the response is not `200 OK` */
+                return false;
+            }
+            finally
+            {
+                // Don't forget to close your response.
+                if (response != null)
+                {
+                    response.Close();
+                }
+            }
+
+            return true;
+        }
+
+        private bool IsTorrentFile(String url)
+        {
+
         }
     }
 }

--- a/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
+++ b/Sulfur/Services/UrlFileDownloadActions/UrlFileDownloadService.cs
@@ -57,12 +57,13 @@ namespace Sulfur.Services.UrlFileDownloadActions
             return true;
         }
 
+        //Checks if the file is a torrent file
         private bool IsTorrentFile(String url, byte[] torrentFileAsBytes)
         {
-            MimeGuesser.GuessExtension(torrentFileAsBytes); //=> image/jpeg
+            //Attempts to guess and return the file type
+            string mimeType = MimeGuesser.GuessMimeType(torrentFileAsBytes); //=> image/jpeg
 
-
-            //if(fileType.Mime)
+            return mimeType.Equals(ServiceConstants.TorrentFileType);
         }
 
         //Attempts to download the file into a byte array

--- a/Sulfur/Services/UrlHeaderActions/IUrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/IUrlActionService.cs
@@ -9,6 +9,7 @@ namespace Sulfur.Services.UrlHeaderActions
     public interface IUrlActionService
     {
         bool SuccessfulMatchOnHeaderToken(String headerToken);
+        bool ValidUrl(String url);
 
         GuidResult GenerateGuidPayload();
     }

--- a/Sulfur/Services/UrlHeaderActions/IUrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/IUrlActionService.cs
@@ -1,4 +1,5 @@
-﻿using Sulfur.Models;
+﻿using Sulfur.Constants;
+using Sulfur.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,6 @@ namespace Sulfur.Services.UrlHeaderActions
     {
         bool SuccessfulMatchOnHeaderToken(String headerToken);
 
-        GuidResult GenerateGuidPayload();
+        GuidResult GenerateGuidPayload(bool ableToProcessUrl, ServiceConstants.UrlFileDlEnums urlFileDlEnum);
     }
 }

--- a/Sulfur/Services/UrlHeaderActions/IUrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/IUrlActionService.cs
@@ -9,7 +9,6 @@ namespace Sulfur.Services.UrlHeaderActions
     public interface IUrlActionService
     {
         bool SuccessfulMatchOnHeaderToken(String headerToken);
-        bool ValidUrl(String url);
 
         GuidResult GenerateGuidPayload();
     }

--- a/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
@@ -3,6 +3,7 @@ using Sulfur.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Sulfur.Services.UrlHeaderActions
@@ -28,7 +29,30 @@ namespace Sulfur.Services.UrlHeaderActions
         //Returns whether the url is valid
         public bool ValidUrl(string url)
         {
-            throw new NotImplementedException();
+            HttpWebResponse response = null;
+            var request = (HttpWebRequest)WebRequest.Create(url);
+            request.Method = "HEAD";
+
+
+            try
+            {
+                response = (HttpWebResponse)request.GetResponse();
+            }
+            catch (WebException ex)
+            {
+                /* A WebException will be thrown if the status of the response is not `200 OK` */
+                return false;
+            }
+            finally
+            {
+                // Don't forget to close your response.
+                if (response != null)
+                {
+                    response.Close();
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Sulfur.Services.UrlHeaderActions
 {
-    public class UrlHeaderService : IUrlActionService
+    public class UrlActionService : IUrlActionService
     {
         //Checks whether the auth header token matches our predefined value
         public bool SuccessfulMatchOnHeaderToken(string headerToken)
@@ -23,6 +23,12 @@ namespace Sulfur.Services.UrlHeaderActions
             GuidResult guidCode = new GuidResult();
             guidCode.Id = code.ToString();
             return guidCode;
+        }
+
+        //Returns whether the url is valid
+        public bool ValidUrl(string url)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
@@ -26,33 +26,6 @@ namespace Sulfur.Services.UrlHeaderActions
             return guidCode;
         }
 
-        //Returns whether the url is valid
-        public bool ValidUrl(string url)
-        {
-            HttpWebResponse response = null;
-            var request = (HttpWebRequest)WebRequest.Create(url);
-            request.Method = "HEAD";
 
-
-            try
-            {
-                response = (HttpWebResponse)request.GetResponse();
-            }
-            catch (WebException ex)
-            {
-                /* A WebException will be thrown if the status of the response is not `200 OK` */
-                return false;
-            }
-            finally
-            {
-                // Don't forget to close your response.
-                if (response != null)
-                {
-                    response.Close();
-                }
-            }
-
-            return true;
-        }
     }
 }

--- a/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
@@ -18,7 +18,7 @@ namespace Sulfur.Services.UrlHeaderActions
 
         //Create a new Guid code to be sent back as a response.
         //TODO In the future, the UrlPayload will be 
-        public GuidResult GenerateGuidPayload()
+        public GuidResult GenerateGuidPayload(bool ableToProcess, ServiceConstants.UrlFileDlEnums resultEnum)
         {
             Guid code = Guid.NewGuid();
             GuidResult guidCode = new GuidResult();

--- a/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
+++ b/Sulfur/Services/UrlHeaderActions/UrlActionService.cs
@@ -16,14 +16,35 @@ namespace Sulfur.Services.UrlHeaderActions
             return headerToken.Equals(ServiceConstants.AuthTokenPassword);
         }
 
-        //Create a new Guid code to be sent back as a response.
-        //TODO In the future, the UrlPayload will be 
+        //Creates an appropriate message and boolean, based on if the url was able to be processed successfully
         public GuidResult GenerateGuidPayload(bool ableToProcess, ServiceConstants.UrlFileDlEnums resultEnum)
         {
+            String errormessage = "";
+
             Guid code = Guid.NewGuid();
-            GuidResult guidCode = new GuidResult();
-            guidCode.Id = code.ToString();
-            return guidCode;
+            String guid = code.ToString();
+
+            GuidResult responsePayload = new GuidResult();
+
+            switch (resultEnum)
+            {
+                case ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT:
+                    errormessage = ServiceConstants.FileIncorrectFormat;
+                    responsePayload.success = "false";
+                    responsePayload.error = errormessage;
+                    return responsePayload;
+
+                case ServiceConstants.UrlFileDlEnums.WEBURLISNOTVALID:
+                    errormessage = ServiceConstants.InvalidWebUrl;
+                    responsePayload.success = "false";
+                    responsePayload.error = errormessage;
+                    return responsePayload;
+            }
+
+            responsePayload.Id = guid;
+            responsePayload.success = "true";
+            responsePayload.error = errormessage;
+            return responsePayload;
         }
 
 

--- a/Sulfur/Startup.cs
+++ b/Sulfur/Startup.cs
@@ -29,7 +29,7 @@ namespace Sulfur
         public void ConfigureServices(IServiceCollection services)
         {
             //Dependency injection of the service into the torrent file controller
-            services.AddScoped<IUrlActionService, UrlHeaderService>();
+            services.AddScoped<IUrlActionService, UrlActionService>();
 
             //Specifies also that it will use an in memory database
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);

--- a/Sulfur/Startup.cs
+++ b/Sulfur/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Sulfur.Models;
+using Sulfur.Services.UrlFileDownloadActions;
 using Sulfur.Services.UrlHeaderActions;
 
 namespace Sulfur
@@ -30,6 +31,7 @@ namespace Sulfur
         {
             //Dependency injection of the service into the torrent file controller
             services.AddScoped<IUrlActionService, UrlActionService>();
+            services.AddScoped<IUrlFileDownloadService, UrlFileDownloadService>();
 
             //Specifies also that it will use an in memory database
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);

--- a/Sulfur/Sulfur.csproj
+++ b/Sulfur/Sulfur.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Mime" Version="3.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Sulfur/Sulfur.csproj
+++ b/Sulfur/Sulfur.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Mime-Detective" Version="0.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Sulfur/Sulfur.csproj
+++ b/Sulfur/Sulfur.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Mime-Detective" Version="0.0.5" />
   </ItemGroup>
 
 </Project>

--- a/SulfurXunitTests/SulfurXunitTests.csproj
+++ b/SulfurXunitTests/SulfurXunitTests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Mime-Detective" Version="0.0.5" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/SulfurXunitTests/SulfurXunitTests.csproj
+++ b/SulfurXunitTests/SulfurXunitTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Mime" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/SulfurXunitTests/SulfurXunitTests.csproj
+++ b/SulfurXunitTests/SulfurXunitTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Mime-Detective" Version="0.0.5" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -99,10 +99,10 @@ namespace SulfurXunitTests
             Assert.False(boolRepresentationOfString);
         }
 
-        //We put a valid url 'www.google.com', it should fail with the error 'file incorrect format'
-        //Signifying a file was downloaded but it was not a torrent file.
+        //We put a valid  torrent url 'http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent', 
+        //it should succeed and the error field should be blank
         [Fact]
-        public void GuidGeneratePostRequestTest()
+        public void SuccessfulTorrentUrlAndFileDownload()
         {
             //Setup
             var mockUrlPayloadRequest = new Mock<UrlPayload>();
@@ -110,7 +110,7 @@ namespace SulfurXunitTests
             var mockUrlFileDownloadService = new Mock<UrlFileDownloadService>();
 
             //Sets up the url field to return google.com
-            mockUrlPayloadRequest.Setup(s => s.Url).Returns("https://google.com");
+            mockUrlPayloadRequest.Setup(s => s.Url).Returns("http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent");
 
             var controller = new TorrentFileController(mockUrlHeaderService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -122,17 +122,17 @@ namespace SulfurXunitTests
             //Assert that it is of the type GuidResult
             Assert.IsType<ActionResult<GuidResult>>(result);
 
-            //Assert that the Guid Payload string is not null or empty
-            Assert.True(String.IsNullOrEmpty(result.Value.Id));
+            //Assert that the Guid Payload string is not empty, as the url does contain a torrent file
+            Assert.False(String.IsNullOrEmpty(result.Value.Id));
 
+            //the error message should be blank
+            Assert.True(String.IsNullOrEmpty(result.Value.error));
 
-            bool resultMatch = false;
-            if (result.Value.error.Equals(ServiceConstants.FileIncorrectFormat))
-                resultMatch = true;
+            //Boolean parse, returns the boolean parsed from the string
+            bool boolRepresentationOfString = Boolean.Parse(result.Value.success);
 
-            Assert.True(resultMatch);
-
-            Assert.True(Boolean.Parse(result.Value.success));
+            //Should be true, as it was able to parse the url and download the file
+            Assert.True(boolRepresentationOfString);
         }
     }
 }

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Sulfur;
 using Sulfur.Constants;
 using Sulfur.Models;
+using Sulfur.Services.UrlFileDownloadActions;
 using Sulfur.Services.UrlHeaderActions;
 using System;
 using System.Collections.Generic;
@@ -17,19 +18,18 @@ namespace SulfurXunitTests
 {
     public class TorrentFileControllerTests
     {
-        //Need to fix the tests to somehow mock the header 
+        //We put a valid url 'www.google.com', it should fail with the error 'file incorrect format'
+        //Signifying a file was downloaded but it was not a torrent file.
         [Fact]
         public void GuidGeneratePostRequestTest()
         {
             //Setup
             var mockUrlPayloadRequest = new Mock<UrlPayload>();
             var mockUrlHeaderService = new Mock<UrlActionService>();
+            var mockUrlFileDownloadService = new Mock<UrlFileDownloadService>();
 
             //Sets up the url field to return google.com
-            mockUrlPayloadRequest.Setup(s => s.Url).Returns("google.com");
-
-            //var request = new HttpRequestMessage(HttpMethod.Post, "http://stackoverflow");
-            //request.Headers.Add(WebConstants.AuthHeaderKeyValue, ServiceConstants.AuthTokenPassword);
+            mockUrlPayloadRequest.Setup(s => s.Url).Returns("https://google.com");
 
             var controller = new TorrentFileController(mockUrlHeaderService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -42,7 +42,16 @@ namespace SulfurXunitTests
             Assert.IsType<ActionResult<GuidResult>>(result);
 
             //Assert that the Guid Payload string is not null or empty
-            Assert.False(String.IsNullOrEmpty(result.Value.Id));
+            Assert.True(String.IsNullOrEmpty(result.Value.Id));
+
+
+            bool resultMatch = false;
+            if (result.Value.error.Equals(ServiceConstants.FileIncorrectFormat))
+                resultMatch = true;
+
+            Assert.True(resultMatch);
+
+            Assert.True(Boolean.Parse(result.Value.success));
         }
     }
 }

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -134,5 +134,32 @@ namespace SulfurXunitTests
             //Should be true, as it was able to parse the url and download the file
             Assert.True(boolRepresentationOfString);
         }
+
+
+        //Authorization token should fail
+        [Fact]
+        public void AuthorizationTokenFail()
+        {
+            //Setup
+            var mockUrlPayloadRequest = new Mock<UrlPayload>();
+            var mockUrlHeaderService = new Mock<UrlActionService>();
+            var mockUrlFileDownloadService = new Mock<UrlFileDownloadService>();
+
+            //Sets up the url field to return google.com
+            mockUrlPayloadRequest.Setup(s => s.Url).Returns("http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent");
+
+            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+            controller.Request.Headers.Add("Authorization", "false");
+
+            //Act
+            var result = controller.PostUrlPayload(mockUrlPayloadRequest.Object);
+
+            //Assert that it is of the type GuidResult
+            Assert.IsType<ActionResult<GuidResult>>(result);
+
+            //Assert that the Guid Payload string is not empty, as the url does contain a torrent file
+            Assert.True(String.IsNullOrEmpty(result.ToString()));
+        }
     }
 }

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -155,11 +155,8 @@ namespace SulfurXunitTests
             //Act
             var result = controller.PostUrlPayload(mockUrlPayloadRequest.Object);
 
-            //Assert that it is of the type GuidResult
-            Assert.IsType<ActionResult<GuidResult>>(result);
-
-            //Assert that the Guid Payload string is not empty, as the url does contain a torrent file
-            Assert.True(String.IsNullOrEmpty(result.ToString()));
+            //Should be blank as auth test failed
+            Assert.True(result.Value==null);
         }
     }
 }

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -31,7 +31,7 @@ namespace SulfurXunitTests
             //Sets up the url field to return google.com
             mockUrlPayloadRequest.Setup(s => s.Url).Returns("https://google.com");
 
-            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            var controller = new TorrentFileController(mockUrlHeaderService.Object, mockUrlFileDownloadService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
             controller.Request.Headers.Add("Authorization", ServiceConstants.AuthTokenPassword); 
 
@@ -72,7 +72,7 @@ namespace SulfurXunitTests
             //Sets up the url field to return google.com
             mockUrlPayloadRequest.Setup(s => s.Url).Returns("https://google");
 
-            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            var controller = new TorrentFileController(mockUrlHeaderService.Object, mockUrlFileDownloadService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
             controller.Request.Headers.Add("Authorization", ServiceConstants.AuthTokenPassword);
 
@@ -112,7 +112,7 @@ namespace SulfurXunitTests
             //Sets up the url field to return google.com
             mockUrlPayloadRequest.Setup(s => s.Url).Returns("http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent");
 
-            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            var controller = new TorrentFileController(mockUrlHeaderService.Object, mockUrlFileDownloadService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
             controller.Request.Headers.Add("Authorization", ServiceConstants.AuthTokenPassword);
 
@@ -148,7 +148,7 @@ namespace SulfurXunitTests
             //Sets up the url field to return google.com
             mockUrlPayloadRequest.Setup(s => s.Url).Returns("http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent");
 
-            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            var controller = new TorrentFileController(mockUrlHeaderService.Object, mockUrlFileDownloadService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
             controller.Request.Headers.Add("Authorization", "false");
 

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -23,7 +23,7 @@ namespace SulfurXunitTests
         {
             //Setup
             var mockUrlPayloadRequest = new Mock<UrlPayload>();
-            var mockUrlHeaderService = new Mock<UrlHeaderService>();
+            var mockUrlHeaderService = new Mock<UrlActionService>();
 
             //Sets up the url field to return google.com
             mockUrlPayloadRequest.Setup(s => s.Url).Returns("google.com");

--- a/SulfurXunitTests/TorrentFileControllerTests.cs
+++ b/SulfurXunitTests/TorrentFileControllerTests.cs
@@ -21,7 +21,7 @@ namespace SulfurXunitTests
         //We put a valid url 'www.google.com', it should fail with the error 'file incorrect format'
         //Signifying a file was downloaded but it was not a torrent file.
         [Fact]
-        public void GuidGeneratePostRequestTest()
+        public void FileIncorrectFormatPayloadPostRequestTest()
         {
             //Setup
             var mockUrlPayloadRequest = new Mock<UrlPayload>();
@@ -34,6 +34,87 @@ namespace SulfurXunitTests
             var controller = new TorrentFileController(mockUrlHeaderService.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
             controller.Request.Headers.Add("Authorization", ServiceConstants.AuthTokenPassword); 
+
+            //Act
+            var result = controller.PostUrlPayload(mockUrlPayloadRequest.Object);
+
+            //Assert that it is of the type GuidResult
+            Assert.IsType<ActionResult<GuidResult>>(result);
+
+            //Assert that the Guid Payload is empty as it was unable to download a torrent file
+            Assert.True(String.IsNullOrEmpty(result.Value.Id));
+
+            bool resultMatch = false;
+            //the error message should match the 'FileIncorrectFormat' message, as the file downloaded
+            //is a html file not a torrent file
+            if (result.Value.error.Equals(ServiceConstants.FileIncorrectFormat))
+                resultMatch = true;
+
+            Assert.True(resultMatch);
+
+            //Boolean parse, returns the boolean parsed from the string
+            bool boolRepresentationOfString = Boolean.Parse(result.Value.success);
+
+            //boolean should be false, as the download was not a success.
+            Assert.False(boolRepresentationOfString);
+        }
+
+        //We put a valid url 'www.google.com', it should fail with the error 'file incorrect format'
+        //Signifying a file was downloaded but it was not a torrent file.
+        [Fact]
+        public void InvalidUrlPayloadPostRequestTest()
+        {
+            //Setup
+            var mockUrlPayloadRequest = new Mock<UrlPayload>();
+            var mockUrlHeaderService = new Mock<UrlActionService>();
+            var mockUrlFileDownloadService = new Mock<UrlFileDownloadService>();
+
+            //Sets up the url field to return google.com
+            mockUrlPayloadRequest.Setup(s => s.Url).Returns("https://google");
+
+            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+            controller.Request.Headers.Add("Authorization", ServiceConstants.AuthTokenPassword);
+
+            //Act
+            var result = controller.PostUrlPayload(mockUrlPayloadRequest.Object);
+
+            //Assert that it is of the type GuidResult
+            Assert.IsType<ActionResult<GuidResult>>(result);
+
+            //Assert that the Guid Payload string is empty, as the url was invalid.
+            Assert.True(String.IsNullOrEmpty(result.Value.Id));
+
+            bool resultMatch = false;
+            //the error message should match the 'InvalidWebUrl' message, as the url is invalid
+            if (result.Value.error.Equals(ServiceConstants.InvalidWebUrl))
+                resultMatch = true;
+
+            Assert.True(resultMatch);
+
+            //Boolean parse, returns the boolean parsed from the string
+            bool boolRepresentationOfString = Boolean.Parse(result.Value.success);
+
+            //Should be false, as it was unable to parse the url
+            Assert.False(boolRepresentationOfString);
+        }
+
+        //We put a valid url 'www.google.com', it should fail with the error 'file incorrect format'
+        //Signifying a file was downloaded but it was not a torrent file.
+        [Fact]
+        public void GuidGeneratePostRequestTest()
+        {
+            //Setup
+            var mockUrlPayloadRequest = new Mock<UrlPayload>();
+            var mockUrlHeaderService = new Mock<UrlActionService>();
+            var mockUrlFileDownloadService = new Mock<UrlFileDownloadService>();
+
+            //Sets up the url field to return google.com
+            mockUrlPayloadRequest.Setup(s => s.Url).Returns("https://google.com");
+
+            var controller = new TorrentFileController(mockUrlHeaderService.Object);
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+            controller.Request.Headers.Add("Authorization", ServiceConstants.AuthTokenPassword);
 
             //Act
             var result = controller.PostUrlPayload(mockUrlPayloadRequest.Object);

--- a/SulfurXunitTests/UrlActionServiceTests.cs
+++ b/SulfurXunitTests/UrlActionServiceTests.cs
@@ -14,7 +14,7 @@ namespace SulfurXunitTests
         private readonly IUrlActionService actionService;
         public UrlActionServiceTests()
         {
-            var mock = new Mock<UrlHeaderService>();
+            var mock = new Mock<UrlActionService>();
             actionService = mock.Object;
         }
 
@@ -32,6 +32,18 @@ namespace SulfurXunitTests
             GuidResult resultPayload = actionService.GenerateGuidPayload();
 
             Assert.False(String.IsNullOrEmpty(resultPayload.Id));
+        }
+
+        [Fact]
+        public void ValidUrlTest()
+        {
+            String validUrl = "https://www.google.com";
+            String invalidUrl = "https://www.google";
+            String invalidUrl2 = "https://google";
+
+            Assert.True()
+
+
         }
     }
 }

--- a/SulfurXunitTests/UrlActionServiceTests.cs
+++ b/SulfurXunitTests/UrlActionServiceTests.cs
@@ -41,7 +41,9 @@ namespace SulfurXunitTests
             String invalidUrl = "https://www.google";
             String invalidUrl2 = "https://google";
 
-            Assert.True()
+            Assert.True(actionService.ValidUrl(validUrl));
+            Assert.False(actionService.ValidUrl(invalidUrl));
+            Assert.False(actionService.ValidUrl(invalidUrl2));
 
 
         }

--- a/SulfurXunitTests/UrlActionServiceTests.cs
+++ b/SulfurXunitTests/UrlActionServiceTests.cs
@@ -34,18 +34,5 @@ namespace SulfurXunitTests
             Assert.False(String.IsNullOrEmpty(resultPayload.Id));
         }
 
-        [Fact]
-        public void ValidUrlTest()
-        {
-            String validUrl = "https://www.google.com";
-            String invalidUrl = "https://www.google";
-            String invalidUrl2 = "https://google";
-
-            Assert.True(actionService.ValidUrl(validUrl));
-            Assert.False(actionService.ValidUrl(invalidUrl));
-            Assert.False(actionService.ValidUrl(invalidUrl2));
-
-
-        }
     }
 }

--- a/SulfurXunitTests/UrlActionServiceTests.cs
+++ b/SulfurXunitTests/UrlActionServiceTests.cs
@@ -25,31 +25,37 @@ namespace SulfurXunitTests
             Assert.True(actionService.SuccessfulMatchOnHeaderToken(ServiceConstants.AuthTokenPassword));
         }
 
-        //Just checking that the string generated from the payload service is not blank or null.
+        //When file has an incorrect format a certain guid should be generated
         [Fact]
-        public void GenerateNonBlankGuidPayloadString()
+        public void GenerateGuidWhenFileIsIncorrectFormat()
         {
-            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
+            GuidResult resultPayload = actionService.GenerateGuidPayload(false, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
 
-            Assert.False(String.IsNullOrEmpty(resultPayload.Id));
+            Assert.True(String.IsNullOrEmpty(resultPayload.Id));
+            Assert.False(Boolean.Parse(resultPayload.success));
+            Assert.Equal(resultPayload.error, ServiceConstants.FileIncorrectFormat);
         }
 
-        //Just checking that the string generated from the payload service is not blank or null.
+        //When url is not valid a certain guid should be generated
         [Fact]
-        public void GenerateNonBlankGuidPayloadString()
+        public void GenerateGuidWhenUrlIsInvalid()
         {
-            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
+            GuidResult resultPayload = actionService.GenerateGuidPayload(false, ServiceConstants.UrlFileDlEnums.WEBURLISNOTVALID);
 
-            Assert.False(String.IsNullOrEmpty(resultPayload.Id));
+            Assert.True(String.IsNullOrEmpty(resultPayload.Id));
+            Assert.False(Boolean.Parse(resultPayload.success));
+            Assert.Equal(resultPayload.error, ServiceConstants.InvalidWebUrl);
         }
 
-        //Just checking that the string generated from the payload service is not blank or null.
+        //When url is valid and torrent file exists
         [Fact]
-        public void GenerateNonBlankGuidPayloadString()
+        public void GenerateGuidWhenUrlIsValidAndTorrentFileExists()
         {
-            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
+            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.SUCCESS);
 
             Assert.False(String.IsNullOrEmpty(resultPayload.Id));
+            Assert.True(Boolean.Parse(resultPayload.success));
+            Assert.True(String.IsNullOrEmpty(resultPayload.error));
         }
     }
 }

--- a/SulfurXunitTests/UrlActionServiceTests.cs
+++ b/SulfurXunitTests/UrlActionServiceTests.cs
@@ -29,10 +29,27 @@ namespace SulfurXunitTests
         [Fact]
         public void GenerateNonBlankGuidPayloadString()
         {
-            GuidResult resultPayload = actionService.GenerateGuidPayload();
+            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
 
             Assert.False(String.IsNullOrEmpty(resultPayload.Id));
         }
 
+        //Just checking that the string generated from the payload service is not blank or null.
+        [Fact]
+        public void GenerateNonBlankGuidPayloadString()
+        {
+            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
+
+            Assert.False(String.IsNullOrEmpty(resultPayload.Id));
+        }
+
+        //Just checking that the string generated from the payload service is not blank or null.
+        [Fact]
+        public void GenerateNonBlankGuidPayloadString()
+        {
+            GuidResult resultPayload = actionService.GenerateGuidPayload(true, ServiceConstants.UrlFileDlEnums.FILEINCORRECTFORMAT);
+
+            Assert.False(String.IsNullOrEmpty(resultPayload.Id));
+        }
     }
 }

--- a/SulfurXunitTests/UrlFileDownloadServiceTests.cs
+++ b/SulfurXunitTests/UrlFileDownloadServiceTests.cs
@@ -19,15 +19,13 @@ namespace SulfurXunitTests
         [Fact]
         public void UrlDownloadFileTest()
         {
-            String validUrl = "https://www.google.com";
             String invalidUrl = "https://www.google";
-            String invalidUrl2 = "https://google";
+            String fileIsNotTorrentFile = "https://www.google.com";
+            String success = "http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent";
 
-            Assert.True(actionService.ValidUrl(validUrl));
-            Assert.False(actionService.ValidUrl(invalidUrl));
-            Assert.False(actionService.ValidUrl(invalidUrl2));
-
-
+            Assert.False(urlFileDownloadService.ProcessUrl(invalidUrl).Item1);
+            Assert.False(urlFileDownloadService.ProcessUrl(fileIsNotTorrentFile).Item1);
+            Assert.True(urlFileDownloadService.ProcessUrl(success).Item1);
         }
     }
 }

--- a/SulfurXunitTests/UrlFileDownloadServiceTests.cs
+++ b/SulfurXunitTests/UrlFileDownloadServiceTests.cs
@@ -17,14 +17,26 @@ namespace SulfurXunitTests
         }
 
         [Fact]
-        public void UrlDownloadFileTest()
+        public void UrlDownloadInvalidUrlTest()
         {
             String invalidUrl = "https://www.google";
-            String fileIsNotTorrentFile = "https://www.google.com";
-            String success = "http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent";
 
             Assert.False(urlFileDownloadService.ProcessUrl(invalidUrl).Item1);
+        }
+
+        [Fact]
+        public void UrlDownloadInvalidUrlDownloadFileTest()
+        {
+            String fileIsNotTorrentFile = "https://www.google.com";
+
             Assert.False(urlFileDownloadService.ProcessUrl(fileIsNotTorrentFile).Item1);
+        }
+
+        [Fact]
+        public void SuccessUrlDownloadFileTest()
+        {
+            String success = "http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent";
+
             Assert.True(urlFileDownloadService.ProcessUrl(success).Item1);
         }
     }

--- a/SulfurXunitTests/UrlFileDownloadServiceTests.cs
+++ b/SulfurXunitTests/UrlFileDownloadServiceTests.cs
@@ -1,0 +1,33 @@
+﻿using Moq;
+using Sulfur.Services.UrlFileDownloadActions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SulfurXunitTests
+{
+    public class UrlFileDownloadServiceTests
+    {
+        private readonly IUrlFileDownloadService urlFileDownloadService;
+        public UrlFileDownloadServiceTests()
+        {
+            var mock = new Mock<UrlFileDownloadService>();
+            urlFileDownloadService = mock.Object;
+        }
+
+        [Fact]
+        public void UrlDownloadFileTest()
+        {
+            String validUrl = "https://www.google.com";
+            String invalidUrl = "https://www.google";
+            String invalidUrl2 = "https://google";
+
+            Assert.True(actionService.ValidUrl(validUrl));
+            Assert.False(actionService.ValidUrl(invalidUrl));
+            Assert.False(actionService.ValidUrl(invalidUrl2));
+
+
+        }
+    }
+}


### PR DESCRIPTION
On submitting a post request to /api/torrentfile with the JSON ->
{ "url":""}
'url' field containing a valid url that points to a torrent file.

You will receive back 
{
"success":"true",
"id":"#####",
"error":""
}

If the url is not valid, you will back an error: 'Web url is not valid'.
If the file at the url, is not a torrent file you will receive back: 'File at url address is not a torrent file'